### PR TITLE
More intelligent protocol selection

### DIFF
--- a/libgrabsite/dashboard.html
+++ b/libgrabsite/dashboard.html
@@ -1561,7 +1561,13 @@ Dashboard.prototype.handleData = function(data) {
 };
 
 Dashboard.prototype.connectWebSocket = function() {
-	this.ws = new WebSocket("ws://" + this.host + "/stream");
+    var loc = window.location, protocol;
+    if (loc.protocol === "https:") {
+        protocol = "wss:";
+    } else {
+        protocol = "ws:";
+    }
+	this.ws = new WebSocket(protocol + "//" + this.host + "/stream");
 
 	this.ws.onmessage = function(ev) {
 		this.queue.push(ev["data"]);


### PR DESCRIPTION
added logic to use wss:// if the site url starts with https:// for those that run the dashboard behind a reverse proxy.
Noticed that issue when i ran it proxied in a subfolder on my main server for a more convenient url to check stuff