### PR TITLE
Fix --which-wpull-command not working correctly with certain paths

### DIFF
--- a/libgrabsite/main.py
+++ b/libgrabsite/main.py
@@ -353,7 +353,7 @@ permanent_error_status_codes, which_wpull_args_partial, which_wpull_command):
 	# only reason to use this is if you're starting wpull manually with modified
 	# arguments, and wpull_hooks.py requires the control files.
 	if which_wpull_command:
-		bin = sys.argv[0].replace("/grab-site", "/wpull") # TODO
+		bin = re.sub("/grab-site$", "/wpull", sys.argv[0])
 		print("GRAB_SITE_WORKING_DIR={} DUPESPOTTER_ENABLED={} {} {}".format(
 			working_dir, int(dupespotter), bin, " ".join(shlex.quote(a) for a in args)))
 		return


### PR DESCRIPTION
Previously, the `--which-wpull-command` flag would replace all occurrences of `/grab-site` with `/wpull`, eg `/home/grab-site/gs-venv/bin/grab-site` became `/home/wpull/gs-venv/bin/wpull`.

This PR fixes that behaviour by using regex instead.