### PR TITLE
Fallback to re if re2 can't be imported

### DIFF
--- a/libgrabsite/wpull_hooks.py
+++ b/libgrabsite/wpull_hooks.py
@@ -1,5 +1,8 @@
 import re
-import re2
+try:
+	import re2
+except ImportError:
+	pass
 import os
 import sys
 import time
@@ -28,13 +31,14 @@ def cf(fname):
 def re_compile(regexp):
 	# Validate with re first, because re2 may be more prone to segfaulting on
 	# bad regexps, and because re returns useful errors.
-	re.compile(regexp)
+	compiled = re.compile(regexp)
 	try:
-		return re2.compile(regexp)
-	except re.error:
+		compiled = re2.compile(regexp)
+	except (re.error, NameError):
 		# Regular expressions with lookaround expressions cannot be compiled with
-		# re2, so on error try compiling with re.
-		return re.compile(regexp)
+		# re2, so on error (or if re2 is unavailable) use the one compiled with re.
+		pass
+	return compiled
 
 def compile_combined_regexp(patterns):
 	# If there are no patterns, we want to ignore nothing, not everything.


### PR DESCRIPTION
At the moment if re2 can't be imported (eg `libre2.so.4` is missing) the dashboard silently stops working entirely (no errors).

This PR makes it so it falls back to using re instead.