### PR TITLE
Fix FB-RE2 build error in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
 	"manhole>=1.0.0",
 	"lmdb>=0.89",
 	"autobahn>=0.12.1",
-	"fb-re2>=1.0.6",
+	"google-re2>=1.0.6",
 	"websockets>=6.0",
 ]
 


### PR DESCRIPTION
Quick fix for the FB-RE2 issue. I installed from my fork instead of main repo and it worked well.

https://github.com/ArchiveTeam/grab-site/issues/239
https://github.com/ArchiveTeam/grab-site/issues/234